### PR TITLE
Update kit/log To New API

### DIFF
--- a/db.go
+++ b/db.go
@@ -157,7 +157,7 @@ func Open(dir string, l log.Logger, r prometheus.Registerer, opts *Options) (db 
 
 	if l == nil {
 		l = log.NewLogfmtLogger(os.Stdout)
-		l = log.NewContext(l).With("ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller)
+		l = log.With(l, "ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller)
 	}
 
 	if opts == nil {

--- a/head.go
+++ b/head.go
@@ -86,7 +86,7 @@ func createHeadBlock(dir string, seq int, l log.Logger, mint, maxt int64) (*head
 
 // openHeadBlock creates a new empty head block.
 func openHeadBlock(dir string, l log.Logger) (*headBlock, error) {
-	wal, err := OpenWAL(dir, log.NewContext(l).With("component", "wal"), 5*time.Second)
+	wal, err := OpenWAL(dir, log.With(l, "component", "wal"), 5*time.Second)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
NewContext has been removed couple of weeks back.
Ref: https://github.com/go-kit/kit/releases/tag/v0.4.0