### PR TITLE
Add Sample Back

### DIFF
--- a/head.go
+++ b/head.go
@@ -34,6 +34,11 @@ var (
 	ErrOutOfBounds = errors.New("out of bounds")
 )
 
+type sample struct {
+	t int64
+	v float64
+}
+
 // headBlock handles reads and writes of time series data within a time window.
 type headBlock struct {
 	mtx sync.RWMutex


### PR DESCRIPTION
The compilation and tests are broken as head.go requires sample which
has been moved to another package while moving BufferedSeriesIterator.

Duplication seemed better compared to exposing sample from tsdbutil.