### PR TITLE
Add mockIndex And Refactor Tests To Use That

### DIFF
--- a/index.go
+++ b/index.go
@@ -40,9 +40,10 @@ type IndexWriter interface {
 	WriteLabelIndex(names []string, values []string) error
 
 	// WritePostings writes a postings list for a single label pair.
+	// The Postings here contain refs to the series that were added.
 	WritePostings(name, value string, it Postings) error
 
-	// Close writes any finalization and closes theresources associated with
+	// Close writes any finalization and closes the resources associated with
 	// the underlying writer.
 	Close() error
 }
@@ -416,6 +417,7 @@ type IndexReader interface {
 	LabelValues(names ...string) (StringTuples, error)
 
 	// Postings returns the postings list iterator for the label pair.
+	// The Postings here contain the offsets to the series inside the index.
 	Postings(name, value string) (Postings, error)
 
 	// Series returns the series for the given reference.


### PR DESCRIPTION
The test takes a noticeable amount of time to run due to the large size of the data. I think we should have a smaller dataset for this test.

PS: This was done as an exercise to understand the indexing layer better, its OK if this PR is turned down.